### PR TITLE
Copy SHACL file using Docker instead

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ WORKDIR /app/
 COPY package*.json ./
 RUN npm ci
 COPY --from=build /app/build /app/build
+COPY --from=build /app/shacl /app/shacl
 USER node
 CMD ["npm", "start"]
 EXPOSE 3000

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "gts lint",
     "clean": "gts clean",
-    "compile": "tsc && cp -R shacl/ build/shacl",
+    "compile": "tsc",
     "fix": "gts fix",
     "prepare": "npm run compile",
     "pretest": "npm run compile",


### PR DESCRIPTION
This way, we can have a single `shacl/dataset.jsonld` path
that works both in `npm run dev` and `npm start` (production).